### PR TITLE
LLM-based data augmentation

### DIFF
--- a/actions/perturbation/augment.py
+++ b/actions/perturbation/augment.py
@@ -2,49 +2,114 @@
 
 import nlpaug.augmenter.word as naw
 import torch
-
 from actions.demonstration_utils import get_augmentation_prompt_by_demonstrations
-from actions.prediction.predict import prediction_generation, convert_str_to_options
+from actions.prediction.predict import convert_str_to_options, prediction_generation
 
 
-def get_augmentation(conversation, first_field=None, second_field=None, num_token=64):
-    """
-    Get augmented text based on original text
-    :param num_token: number of max token
-    :param second_field:
-    :param first_field:
+def get_augmentation(conversation, field, num_token=64):
+    """Get augmented text based on original text.
+
     :param conversation: conversation object
+    :param field: input text
+    :param num_token: number of max token
     :return: augmented text
     """
     model = conversation.decoder.gpt_model
     tokenizer = conversation.decoder.gpt_tokenizer
 
-    prompt_template = get_augmentation_prompt_by_demonstrations(conversation.describe.get_dataset_name(),
-                                                                first_field, second_field)
-
+    prompt_template = prompt_template = (
+        "Paraphrase the following text. Please, do not change its meaning and do not add any additional information.\nOriginal text: "
+        + field
+        + "\nParaphrased text:"
+    )
+    if conversation.describe.get_dataset_name() == "ECQA":
+        prompt_template = (
+            "Do not answer any questions, just paraprase the text. Keep the question as question.\nOriginal question: "
+            + field
+            + "\nParaphrased question:"
+        )
     conversation.current_prompt = prompt_template
 
-    input_ids = tokenizer(prompt_template, return_tensors='pt').input_ids.to(model.device.type)
+    input_ids = tokenizer(prompt_template, return_tensors="pt").input_ids.to(model.device.type)
     with torch.no_grad():
-        output = model.generate(inputs=input_ids, temperature=0.7, do_sample=True, top_p=0.95, top_k=40,
-                                max_new_tokens=num_token)
+        output = model.generate(
+            inputs=input_ids,
+            temperature=0.7,
+            do_sample=True,
+            top_p=0.95,
+            top_k=40,
+            max_new_tokens=num_token,
+        )
     result = tokenizer.decode(output[0]).split(prompt_template)[1][:-4]
+    if "\n" in result:
+        result = result[: result.index("\n") + 1]
 
-    return result
+    return result.strip()
+
+
+def get_sample_augmentation(data, conversation, idx, first_field, second_field, aug=None):
+    """Sample-wise data augmentation.
+
+    :param data: current dataset
+    :param conversation: conversation object
+    :param idx: sample ID
+    :param first_field: text of the first field (claim for COVID-Fact, question for ECQA)
+    :param second_field: text of the second field (evidence for ECQA)
+    :param aug: NLPAug word-level augmenter or None if we use LLM prompting
+    :return: augmented fields and model prediction with the new (augmented) inputs
+    """
+    augmented_first_field = None
+    augmented_second_field = None
+    if not conversation.llm_augmentation:
+        assert aug is not None
+        augmented_first_field = aug.augment(first_field)
+        if second_field is not None:
+            augmented_second_field = aug.augment(second_field)
+    else:
+        augmented_first_field = get_augmentation(conversation, field=first_field, num_token=64)
+        if second_field is not None:
+            augmented_second_field = get_augmentation(
+                conversation, field=second_field, num_token=256
+            )
+
+    _, post_prediction = prediction_generation(
+        data,
+        conversation,
+        idx,
+        num_shot=3,
+        given_first_field=augmented_first_field,
+        given_second_field=augmented_second_field,
+    )
+
+    return post_prediction, augmented_first_field, augmented_second_field
 
 
 def augment_operation(conversation, parse_text, i, **kwargs):
-    """Data augmentation."""
-    data = conversation.temp_dataset.contents['X']
-    idx = None
+    """Data augmentation.
 
-    few_shot = False
+    :param conversation: conversation object
+    :param parse_text: parsed operation text (not used)
+    :param i: current index
+    :return: augmented text
+    """
+    data = conversation.temp_dataset.contents["X"]
+    idx = None
 
     if conversation.custom_input is not None and conversation.used is False:
         if conversation.describe.get_dataset_name() == "covid_fact":
-            claim, evidence = conversation.custom_input['first_input'], conversation.custom_input['second_input']
+            claim, evidence = (
+                conversation.custom_input["first_input"],
+                conversation.custom_input["second_input"],
+            )
+            first_field = claim
+            second_field = evidence
         else:
-            question, choices = conversation.custom_input['first_input'], conversation.custom_input['second_input']
+            question, choices = (
+                conversation.custom_input["first_input"],
+                conversation.custom_input["second_input"],
+            )
+            first_field = question
+            second_field = None
     else:
         assert len(conversation.temp_dataset.contents["X"]) == 1
 
@@ -56,62 +121,67 @@ def augment_operation(conversation, parse_text, i, **kwargs):
         if conversation.describe.get_dataset_name() == "covid_fact":
             claim = conversation.get_var("dataset").contents["X"].iloc[idx]["claims"]
             evidence = conversation.get_var("dataset").contents["X"].iloc[idx]["evidences"]
+            first_field = claim
+            second_field = evidence
         else:
             question = conversation.get_var("dataset").contents["X"].iloc[idx]["texts"]
             choices = conversation.get_var("dataset").contents["X"].iloc[idx]["choices"]
+            first_field = question
+            second_field = None
 
     return_s = f"Instance of ID <b>{idx}</b> <br>"
 
-    _, pre_prediction = prediction_generation(data, conversation, idx, num_shot=3,
-                                              given_first_field=None, given_second_field=None)
+    _, pre_prediction = prediction_generation(
+        data,
+        conversation,
+        idx,
+        num_shot=3,
+        given_first_field=first_field,
+        given_second_field=second_field,
+    )
 
-    aug = naw.SynonymAug(aug_src='wordnet')
+    if not conversation.llm_augmentation:
+        aug = naw.SynonymAug(aug_src="wordnet")
+    else:
+        aug = None
+    patience = 2  # how many times we repeat data augmentation to get the output that differs from the original input
+    count_prediction = 0
 
-    # Word augmenter
+    post_prediction, augmented_first_field, augmented_second_field = get_sample_augmentation(
+        data, conversation, idx, first_field, second_field, aug
+    )
+    # repeat data augmentation if prediction changes the label
+    while count_prediction < patience and post_prediction != pre_prediction:
+        count_prediction += 1
+        post_prediction, augmented_first_field, augmented_second_field = get_sample_augmentation(
+            data, conversation, idx, first_field, second_field, aug
+        )
+    # build the return string for the interface
     if conversation.describe.get_dataset_name() == "covid_fact":
-        # Augment both claim and evidence to create a new instance
-        if not few_shot:
-            augmented_first_field = aug.augment(claim)
-            augmented_second_field = aug.augment(evidence)
-        else:
-            augmented_first_field = get_augmentation(conversation, first_field=claim)
-            augmented_second_field = get_augmentation(conversation, second_field=evidence, num_token=512)
-
         return_s += f"<b>Claim</b>: {claim}<br>"
         return_s += f"<b>Original evidence:</b> {evidence}<br>"
-        return_s += f"<b>Prediction before augmentation</b>: <span style=\"background-color: #6CB4EE\">" \
-                    f"{pre_prediction}</span><br><br>"
+        return_s += (
+            f'<b>Prediction before augmentation</b>: <span style="background-color: #6CB4EE">'
+            f"{pre_prediction}</span><br><br>"
+        )
         return_s += f"<b>Augmented claim:</b> {augmented_first_field}<br>"
         return_s += f"<b>Augmented evidence:</b> {augmented_second_field}<br>"
-        _, post_prediction = prediction_generation(data, conversation, idx, num_shot=3,
-                                                   given_first_field=augmented_first_field,
-                                                   given_second_field=augmented_second_field)
+        return_s += (
+            f'<b>Prediction after augmentation</b>: <span style="background-color: #6CB4EE">'
+            f"{post_prediction}</span>"
+        )
     else:
-        if not few_shot:
-            augmented_first_field = aug.augment(question)
-        else:
-            augmented_first_field = get_augmentation(conversation, first_field=question)
-
         split_choices = choices.split("-")
-
-        temp = []
-        for i in split_choices:
-            temp.append(aug.augment(i))
-
         return_s += f"<b>Original question:</b> {question}<br>"
         return_s += f"<b>Original choices:</b> {convert_str_to_options(choices)}<br>"
-        return_s += f"<b>Prediction before augmentation</b>: <span style=\"background-color: #6CB4EE\">" \
-                    f"{split_choices[pre_prediction]}</span><br><br>"
+        return_s += (
+            f'<b>Prediction before augmentation</b>: <span style="background-color: #6CB4EE">'
+            f"{split_choices[pre_prediction]}</span><br><br>"
+        )
         return_s += f"<b>Augmented question:</b> {augmented_first_field}<br>"
-
-        _, post_prediction = prediction_generation(data, conversation, idx, num_shot=3,
-                                                   given_first_field=augmented_first_field, given_second_field=None)
-
-    if conversation.describe.get_dataset_name() == "covid_fact":
-        return_s += f"<b>Prediction after augmentation</b>: <span style=\"background-color: #6CB4EE\">" \
-                    f"{post_prediction}</span>"
-    else:
-        return_s += f"<b>Prediction after augmentation</b>: <span style=\"background-color: #6CB4EE\">" \
-                    f"{split_choices[post_prediction]}</span>"
+        return_s += (
+            f'<b>Prediction after augmentation</b>: <span style="background-color: #6CB4EE">'
+            f"{split_choices[post_prediction]}</span>"
+        )
 
     return return_s, 1

--- a/configs/ecqa_mistral_gptq.gin
+++ b/configs/ecqa_mistral_gptq.gin
@@ -37,6 +37,7 @@ Prompts.num_prompt_template = 7
 
 # Conversation params
 Conversation.class_names = {0: "option1", 1: "option2", 2: "option3", 3: "option4", 4: "option5"}
+Conversation.llm_augmentation = True
 
 # Dataset description
 DatasetDescription.dataset_objective = "choose the correct option from 5 choices based on question"

--- a/logic/conversation.py
+++ b/logic/conversation.py
@@ -1,16 +1,15 @@
 """Contains a representation of the conversation.
 
-The file contains a representation of the conversation. The conversation
-class contains routines to write variable to the conversation, read those
-variables and print a representation of them.
+The file contains a representation of the conversation. The conversation class contains routines to
+write variable to the conversation, read those variables and print a representation of them.
 """
 import copy
-import gin
-import pandas as pd
-from pandas import Series
 from typing import Union
 
+import gin
+import pandas as pd
 from logic.dataset_description import DatasetDescription
+from pandas import Series
 
 
 class Variable:
@@ -52,22 +51,25 @@ class Conversation:
     This class defines the state of the conversation.
     """
 
-    def __init__(self,
-                 class_names: dict = None,
-                 rounding_precision: int = 3,
-                 index_col: int = 0,
-                 target_var_name: str = "y",
-                 default_metric: str = "accuracy",
-                 eval_file_path: str = None,
-                 feature_definitions: dict = None,
-                 decoder = None,
-                 text_fields: list[str] = None,
-        ):
+    def __init__(
+        self,
+        class_names: dict = None,
+        llm_augmentation: bool = True,
+        rounding_precision: int = 3,
+        index_col: int = 0,
+        target_var_name: str = "y",
+        default_metric: str = "accuracy",
+        eval_file_path: str = None,
+        feature_definitions: dict = None,
+        decoder=None,
+        text_fields: list[str] = None,
+    ):
         """
 
         Args:
             data_folder:
             class_names:
+            llm_augmentation:
             rounding_precision:
             index_col:
             target_var_name:
@@ -91,9 +93,9 @@ class Conversation:
         self.username = "unknown"
 
         # The description
-        self.describe = DatasetDescription(index_col=index_col,
-                                           target_var_name=target_var_name,
-                                           eval_file_path=eval_file_path)
+        self.describe = DatasetDescription(
+            index_col=index_col, target_var_name=target_var_name, eval_file_path=eval_file_path
+        )
 
         # Set initial followup to brief description about the data and model
         self.followup = self.describe.get_text_description()
@@ -114,6 +116,9 @@ class Conversation:
         self.user_input = None
         self.prompt_type = "none"
 
+        # Set data augmentation mode (LLM prompting or NLPAug)
+        self.llm_augmentation = llm_augmentation
+
         self.current_prompt = ""
 
         self.precomputation_of_prediction = pd.DataFrame({"id": [], "prediction": []})
@@ -126,7 +131,7 @@ class Conversation:
             return self.feature_definitions[feature_name]
 
     def get_class_name_from_label(self, label: int):
-        """Gets the class name from label"""
+        """Gets the class name from label."""
         if self.class_names is None:
             return str(label)
         else:
@@ -154,26 +159,24 @@ class Conversation:
         dataset = self.stored_vars["dataset"].contents["X"]
         return list(dataset.index)
 
-    def add_dataset(self,
-                    data: pd.DataFrame,
-                    y_value: Series,
-                    categorical: list[str],
-                    numeric: list[str]):
+    def add_dataset(
+        self, data: pd.DataFrame, y_value: Series, categorical: list[str], numeric: list[str]
+    ):
         """Stores data as the dataset in the conversation."""
         dataset = {
-            'X': data,
-            'y': y_value,
-            'cat': categorical,
-            'numeric': numeric,
-            'ids_to_regenerate': []
+            "X": data,
+            "y": y_value,
+            "cat": categorical,
+            "numeric": numeric,
+            "ids_to_regenerate": [],
         }
-        var = Variable(name='dataset', contents=dataset, kind='dataset')
+        var = Variable(name="dataset", contents=dataset, kind="dataset")
         self._store_var(var)
         return var
 
     def build_temp_dataset(self, save=True):
         """Builds a temporary data set for filtering modifications."""
-        temp_dataset = copy.deepcopy(self.get_var('dataset'))
+        temp_dataset = copy.deepcopy(self.get_var("dataset"))
         if save:
             self._update_temp_dataset(temp_dataset)
             self.parse_operation = []
@@ -214,10 +217,10 @@ class Conversation:
 
     def __repr__(self):
         """Could be cool to change this to a graph representation."""
-        out = '<p> Stored Variables:<br>'
+        out = "<p> Stored Variables:<br>"
         for var_name in self.stored_vars:
-            out += f'&emsp;{var_name}<br>'
-        out += '</p>'
+            out += f"&emsp;{var_name}<br>"
+        out += "</p>"
         return out
 
 


### PR DESCRIPTION
This implements an updated version of our data augmentation operation based on LLM prompting. It is currently set as default but can be changed in the config file by adding: `Conversation.llm_augmentation = False` which will switch to the original NLPAug-based data augmentation.

Sample augmentation with NLPAug (not very convincing tbh):
![Screenshot 2024-03-23 at 22-16-24 LLMCheckup](https://github.com/DFKI-NLP/LLMCheckup/assets/9082878/e63a2ffa-6900-4154-be9c-4db209e34071)
LLM-based data augmentation for the same instance:
![Screenshot 2024-03-23 at 22-04-24 LLMCheckup](https://github.com/DFKI-NLP/LLMCheckup/assets/9082878/32d5727d-cd3f-45cb-bc41-39b2821f0b9a)